### PR TITLE
Parameterize port for Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,13 @@ RUN adduser --disabled-password --gecos '' appuser \
 USER appuser
 
 # Expose port
-EXPOSE 5000
+ARG PORT=5000
+ENV PORT=${PORT}
+EXPOSE ${PORT}
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:5000/api/health || exit 1
+    CMD curl -f http://localhost:${PORT}/api/health || exit 1
 
 # Run the application
-CMD ["gunicorn", "--worker-class", "eventlet", "-w", "1", "--bind", "0.0.0.0:5000", "run:app"]
+CMD ["sh", "-c", "gunicorn --worker-class eventlet -w 1 --bind 0.0.0.0:${PORT} run:app"]


### PR DESCRIPTION
## Summary
- make Dockerfile port configurable with `PORT`
- bind Gunicorn to `0.0.0.0:${PORT}` for Railway
- update healthcheck to use dynamic port

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892cd98d5fc832d8943ed7db5767855